### PR TITLE
Fix discovering tables in postgres

### DIFF
--- a/postgresql.go
+++ b/postgresql.go
@@ -41,7 +41,7 @@ func (r *postgresqlResource) Await(ctx context.Context) error {
 
 func awaitPostgreSQLTables(db *sql.DB, dbName string, tables []string) error {
 	if len(tables) == 0 {
-		const stmt = `SELECT count(*) FROM information_schema.tables WHERE table_schema=?`
+		const stmt = `SELECT count(*) FROM information_schema.tables WHERE table_catalog=? AND table_schema='public'`
 		var tableCnt int
 		if err := db.QueryRow(stmt, dbName).Scan(&tableCnt); err != nil {
 			return err
@@ -54,7 +54,7 @@ func awaitPostgreSQLTables(db *sql.DB, dbName string, tables []string) error {
 		return nil
 	}
 
-	const stmt = `SELECT table_name FROM information_schema.tables WHERE table_schema=?`
+	const stmt = `SELECT table_name FROM information_schema.tables WHERE table_catalog=? AND table_schema='public'`
 	rows, err := db.Query(stmt, dbName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Appearently the default for postgres' creating tables is that the `table_catalog` (instead of `table_schema`) gets the name of the database. `table_schema` by default gets `public`.