### PR TITLE
Adds the capability to disable SSL verification for postgres 

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func execCmd(cmdArgs []string) error {
 
 func parseTags(tag string) map[string]string {
 	tags := map[string]string{}
-	tagParts := strings.Split(tag, ",")
+	tagParts := strings.Split(tag, "&")
 	for _, t := range tagParts {
 		kv := strings.SplitN(t, "=", 2)
 		k := kv[0]

--- a/postgresql.go
+++ b/postgresql.go
@@ -15,9 +15,17 @@ type postgresqlResource struct {
 }
 
 func (r *postgresqlResource) Await(ctx context.Context) error {
+	tags := parseTags(r.URL.Fragment)
+
+	dbParams := url.Values{}
+
+	if val, ok := tags["ssl"]; ok && val == "false" {
+		dbParams.Set("sslmode", "disable") // PGSSLMODE
+	}
+
 	dsnURL := r.URL
-	tags := parseTags(dsnURL.Fragment)
 	dsnURL.Fragment = ""
+	dsnURL.RawQuery = dbParams.Encode()
 	dsn := dsnURL.String()
 
 	db, err := sql.Open(r.URL.Scheme, dsn)


### PR DESCRIPTION
* README update still missing

Also, please check the parseTags function, as I think there was a bug there.