### PR TITLE
Improve debugging by exposing error for resource unavailable

### DIFF
--- a/command.go
+++ b/command.go
@@ -27,8 +27,8 @@ func (r *commandResource) Await(ctx context.Context) error {
 	args := cmdParts[1:]
 
 	if err := exec.CommandContext(ctx, cmd, args...).Run(); err != nil {
-		if _, ok := err.(*exec.ExitError); ok {
-			return ErrUnavailable
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return &unavailableError{exitErr}
 		}
 		return err
 	}

--- a/file.go
+++ b/file.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ func (r *fileResource) Await(context.Context) error {
 	_, err := os.Stat(filePath)
 	if _, ok := tags["absent"]; ok {
 		if err == nil {
-			return ErrUnavailable
+			return &unavailableError{errors.New("file exists")}
 		} else if os.IsNotExist(err) {
 			return nil
 		}
@@ -29,7 +30,7 @@ func (r *fileResource) Await(context.Context) error {
 		if err == nil {
 			return nil
 		} else if os.IsNotExist(err) {
-			return ErrUnavailable
+			return &unavailableError{err}
 		}
 	}
 

--- a/http.go
+++ b/http.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"net/url"
 
@@ -27,7 +28,7 @@ func (r *httpResource) Await(ctx context.Context) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return ErrUnavailable
+		return &unavailableError{err}
 	}
 	defer resp.Body.Close()
 
@@ -37,5 +38,5 @@ func (r *httpResource) Await(ctx context.Context) error {
 		return nil
 	}
 
-	return ErrUnavailable
+	return &unavailableError{errors.New(resp.Status)}
 }

--- a/log.go
+++ b/log.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	debugLevel = iota
-	infoLevel
+	infoLevel = iota
 	errorLevel
 	silentLevel
 )
@@ -21,24 +20,6 @@ func NewLogger(level int) *LevelLogger {
 	return &LevelLogger{
 		Logger: log.New(os.Stderr, "", log.LstdFlags),
 		level:  level,
-	}
-}
-
-func (l *LevelLogger) Debug(v ...interface{}) {
-	if l.level <= debugLevel {
-		log.Print(v...)
-	}
-}
-
-func (l *LevelLogger) Debugln(v ...interface{}) {
-	if l.level <= debugLevel {
-		log.Println(v...)
-	}
-}
-
-func (l *LevelLogger) Debugf(format string, v ...interface{}) {
-	if l.level <= debugLevel {
-		log.Printf(format, v...)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 					if e, ok := err.(*unavailableError); ok { // transient error
 						log.Infof("Resource unavailable: %v", e)
 					} else {
-						log.Errorf("Error: awaiting resource: %v", err)
+						log.Errorf("Error: failed to await resource: %v", err)
 					}
 					time.Sleep(retryDelay)
 				} else {
@@ -92,7 +92,7 @@ func main() {
 	case context.Canceled:
 		log.Infoln("All resources available")
 	case context.DeadlineExceeded:
-		log.Infoln("Error: timeout exceeded")
+		log.Infoln("Timeout exceeded")
 		if !*forceFlag {
 			os.Exit(1)
 		}
@@ -101,7 +101,7 @@ func main() {
 	if len(cmdArgs) > 0 {
 		log.Infof("Runnning command: %v", cmdArgs)
 		if err := execCmd(cmdArgs); err != nil {
-			log.Fatalf("Error: %v", err)
+			log.Fatalf("Error: failed to execute command: %v", err)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 
 const retryDelay = 500 * time.Millisecond
 
-type Resource interface {
+type resource interface {
 	fmt.Stringer
 	Await(context.Context) error
 }
@@ -129,7 +129,7 @@ func parseResources(urlArgs []string) ([]url.URL, error) {
 	return urls, nil
 }
 
-func identifyResource(u url.URL) (Resource, error) {
+func identifyResource(u url.URL) (resource, error) {
 	switch u.Scheme {
 	case "http", "https":
 		return &httpResource{u}, nil

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 				return
 			default:
 				res, err := identifyResource(ress[i])
-				if err != nil {
+				if err != nil { // Permanent error
 					log.Fatalf("Error: %v", err)
 				}
 
@@ -75,12 +75,12 @@ func main() {
 				if err := res.Await(ctx); err != nil {
 					if e, ok := err.(*unavailableError); ok { // transient error
 						log.Infof("Resource unavailable: %v", e)
-					} else {
+					} else { // Maybe transient error
 						log.Errorf("Error: failed to await resource: %v", err)
 					}
 					time.Sleep(retryDelay)
 				} else {
-					i++
+					i++ // Next resource
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	if len(cmdArgs) > 0 {
-		log.Debugf("Runnning command: %v", cmdArgs)
+		log.Infof("Runnning command: %v", cmdArgs)
 		if err := execCmd(cmdArgs); err != nil {
 			log.Fatalf("Error: %v", err)
 		}

--- a/mysql.go
+++ b/mysql.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -28,7 +30,7 @@ func (r *mysqlResource) Await(ctx context.Context) error {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		return ErrUnavailable
+		return &unavailableError{err}
 	}
 
 	if val, ok := tags["tables"]; ok {
@@ -49,7 +51,7 @@ func awaitMySQLTables(db *sql.DB, dbName string, tables []string) error {
 		}
 
 		if tableCnt == 0 {
-			return ErrUnavailable
+			return &unavailableError{errors.New("no tables found")}
 		}
 
 		return nil
@@ -86,7 +88,7 @@ func awaitMySQLTables(db *sql.DB, dbName string, tables []string) error {
 
 	for _, t := range tables {
 		if !contains(actualTables, t) {
-			return ErrUnavailable
+			return &unavailableError{fmt.Errorf("table not found: %s", t)}
 		}
 	}
 

--- a/postgresql.go
+++ b/postgresql.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -27,7 +29,7 @@ func (r *postgresqlResource) Await(ctx context.Context) error {
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
-		return ErrUnavailable
+		return &unavailableError{err}
 	}
 
 	if val, ok := tags["tables"]; ok {
@@ -48,7 +50,7 @@ func awaitPostgreSQLTables(db *sql.DB, dbName string, tables []string) error {
 		}
 
 		if tableCnt == 0 {
-			return ErrUnavailable
+			return &unavailableError{errors.New("no tables found")}
 		}
 
 		return nil
@@ -85,7 +87,7 @@ func awaitPostgreSQLTables(db *sql.DB, dbName string, tables []string) error {
 
 	for _, t := range tables {
 		if !contains(actualTables, t) {
-			return ErrUnavailable
+			return &unavailableError{fmt.Errorf("table not found: %s", t)}
 		}
 	}
 

--- a/tcp.go
+++ b/tcp.go
@@ -15,7 +15,7 @@ func (r *tcpResource) Await(ctx context.Context) error {
 	dialer := &net.Dialer{}
 	_, err := dialer.DialContext(ctx, r.URL.Scheme, r.URL.Host)
 	if err != nil {
-		return ErrUnavailable
+		return &unavailableError{err}
 	}
 
 	return nil

--- a/websocket.go
+++ b/websocket.go
@@ -36,7 +36,7 @@ func (r *websocketResource) Await(ctx context.Context) error {
 
 	conn, _, err := wsDialer.Dial(r.URL.String(), nil)
 	if err != nil {
-		return ErrUnavailable
+		return &unavailableError{err}
 	}
 	defer conn.Close()
 


### PR DESCRIPTION
This will help for example with database resources not supporting TLS:

```
2016/10/11 20:25:58 Awaiting resource: mysql://user:pass@db:3306/my_db?tls=true
2016/10/11 20:25:58 Resource unavailable: TLS requested but server does not support TLS
:
2016/10/11 20:28:28 Awaiting resource: postgres://user:pass@db:5432/my_db
2016/10/11 20:28:28 Resource unavailable: pq: SSL is not enabled on the server
```