### PR TITLE
Correctly parse arguments if no resource is given but separator is

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,10 +201,17 @@ func execCmd(cmdArgs []string) error {
 
 func parseTags(tag string) map[string]string {
 	tags := map[string]string{}
+	if tag == "" {
+		return tags
+	}
+
 	tagParts := strings.Split(tag, "&")
 	for _, t := range tagParts {
 		kv := strings.SplitN(t, "=", 2)
 		k := kv[0]
+		if k == "" {
+			continue // Invalid format, skip for now
+		}
 		if len(kv) == 1 {
 			tags[k] = ""
 		} else {

--- a/main.go
+++ b/main.go
@@ -127,12 +127,33 @@ func main() {
 }
 
 func splitArgs(args []string) ([]string, []string) {
-	for i, a := range args {
-		if a == "--" {
-			return args[0:i], args[i+1:]
+	if i := indexOf(args, "--"); i >= 0 {
+		return args[0:i], args[i+1:]
+	}
+
+	// We haven't seen a resource|command separator ('--'). This can either be
+	// because of Go's flag parser removing the separator if no args were given,
+	// or because there actually was none given.
+	// Fallback to the original (unparsed) flag argument list and see if a
+	// separator was given there and if, assume all arguments given are part of
+	// the command, i.e. no resources at all were provided.
+	if i := indexOf(os.Args, "--"); i >= 0 {
+		return []string{}, args
+	}
+
+	// We still haven't seen a resource|command separator ('--'). Now finally
+	// assume because there actually was none given and use all arguments as
+	// resources.
+	return args, []string{}
+}
+
+func indexOf(l []string, s string) int {
+	for i, e := range l {
+		if e == "--" {
+			return i
 		}
 	}
-	return args, []string{}
+	return -1
 }
 
 func parseResources(urlArgs []string) ([]url.URL, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestSplitArgsResourceAndCommand(t *testing.T) {
+	os.Args = []string{"./await", "true", "--", "echo"}
+	flag.Parse()
+	res, cmd := splitArgs(flag.Args())
+	if len(res) != 1 || res[0] != "true" {
+		t.Errorf("no resources found")
+	}
+	if len(cmd) != 1 || cmd[0] != "echo" {
+		t.Errorf("no command found")
+	}
+}
+
+func TestSplitArgsResourceAndNoCommand(t *testing.T) {
+	os.Args = []string{"./await", "true", "--"}
+	flag.Parse()
+	res, cmd := splitArgs(flag.Args())
+	if len(res) != 1 || res[0] != "true" {
+		t.Errorf("no resources found")
+	}
+	if len(cmd) != 0 {
+		t.Errorf("unexpected command found")
+	}
+
+	os.Args = []string{"./await", "true"}
+	flag.Parse()
+	res, cmd = splitArgs(flag.Args())
+	if len(res) != 1 || res[0] != "true" {
+		t.Errorf("no resources found")
+	}
+	if len(cmd) != 0 {
+		t.Errorf("unexpected command found")
+	}
+}
+
+func TestSplitArgsNoResourceAndCommand(t *testing.T) {
+	os.Args = []string{"./await", "--", "echo"}
+	flag.Parse()
+	res, cmd := splitArgs(flag.Args())
+	if len(res) != 0 {
+		t.Errorf("unexpected resource found")
+	}
+	if len(cmd) != 1 || cmd[0] != "echo" {
+		t.Errorf("no command found")
+	}
+}
+
+func TestSplitArgsNoResourceNoCommand(t *testing.T) {
+	os.Args = []string{"./await", "--"}
+	flag.Parse()
+	res, cmd := splitArgs(flag.Args())
+	if len(res) != 0 {
+		t.Errorf("unexpected resource found")
+	}
+	if len(cmd) != 0 {
+		t.Errorf("unexpected command found")
+	}
+
+	os.Args = []string{"./await"}
+	flag.Parse()
+	res, cmd = splitArgs(flag.Args())
+	if len(res) != 0 {
+		t.Errorf("unexpected resource found")
+	}
+	if len(cmd) != 0 {
+		t.Errorf("unexpected command found")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -73,3 +73,28 @@ func TestSplitArgsNoResourceNoCommand(t *testing.T) {
 		t.Errorf("unexpected command found")
 	}
 }
+
+func TestParseTags(t *testing.T) {
+	tests := map[string]map[string]string{
+		"":              map[string]string{},
+		"=":             map[string]string{}, // invalid format, should be skipped
+		"=ignore":       map[string]string{}, // invalid format, should be skipped
+		"foo":           map[string]string{"foo": ""},
+		"foo=":          map[string]string{"foo": ""},
+		"foo=bar":       map[string]string{"foo": "bar"},
+		"foo=bar&baz":   map[string]string{"foo": "bar", "baz": ""},
+		"foo=bar&baz=1": map[string]string{"foo": "bar", "baz": "1"},
+	}
+	for given, expected := range tests {
+		actual := parseTags(given)
+		if len(actual) != len(expected) {
+			t.Errorf("unexpected parsed tags count %d != %d: %#v",
+				len(expected), len(actual), actual)
+		}
+		for actualK, actualV := range actual {
+			if expectedV, ok := expected[actualK]; !ok || actualV != expectedV {
+				t.Errorf("unexpected parsed tags k/v pair")
+			}
+		}
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -74,6 +74,53 @@ func TestSplitArgsNoResourceNoCommand(t *testing.T) {
 	}
 }
 
+func TestParseResourcesSuccess(t *testing.T) {
+	ress := []string{
+		"http://user:pass@localhost:foo/path?query=val#fragment",
+		"https://user:pass@localhost:foo/path?query=val#fragment",
+
+		"ws://user:pass@localhost:42/path?query=val#fragment",
+		"wss://user:pass@localhost:42/path?query=val#fragment",
+
+		"tcp://localhost:42",
+		"tcp4://localhost:42",
+		"tcp6://[::1]:42",
+
+		"file://relative/path/to/file",
+		"file://relative/path/to/file#absent",
+		"file:///absolute/path/to/file",
+		"file://absolute/path/to/file#absent",
+
+		"postgres://user:pass@localhost:5432/dbname?query=val#fragment",
+
+		"mysql://user:pass@localhost:3306/dbname?query=val#fragment",
+
+		"command",
+		"command with args",
+		"relative/path/to/command",
+		"relative/path/to/command with args",
+		"/absolute/path/to/command",
+		"/absolute/path/to/command with args",
+
+		"",
+	}
+
+	actualRess, err := parseResources(ress)
+	if err != nil {
+		t.Errorf("failed to parse ressources")
+	}
+	if len(actualRess) != len(ress) {
+		t.Errorf("missing parsed ressources")
+	}
+}
+
+func TestParseResourcesFailure(t *testing.T) {
+	_, err := parseResources([]string{"//foo test"})
+	if err == nil {
+		t.Errorf("expected error parsing invalid ressource")
+	}
+}
+
 func TestParseTags(t *testing.T) {
 	tests := map[string]map[string]string{
 		"":              map[string]string{},


### PR DESCRIPTION
This is more of a heuristic due to Go's flag parser.

Fixes #17.