### PR TITLE
Make database name optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ URL syntax: `file://<path>[#<fragment>]`
 
 ### PostgreSQL Resource
 
-URL syntax: `postgres://[<user>[:<pass>]@]<host>[:<port>]/<dbname>[?<dbparams>][#<fragment>]`
+URL syntax: `postgres://[<user>[:<pass>]@]<host>[:<port>][/<dbname>][?<dbparams>][#<fragment>]`
 
 The URL defines a [DSN](https://en.wikipedia.org/wiki/Data_source_name).
+
+The database name `<dbname>` is optional. If provided, the resource is
+classified as available as soon as the database was found.
 
 DB Parameters:
 
@@ -90,14 +93,17 @@ Fragment:
 - `tables[=t1,t2,...]` key-value: If key present and value absent, the
   resource's database scheme must at least contain one table. If key present and
   value present, the resource's database scheme must at least contain the
-  specified tables.
+  specified tables. Using this key requires to provide a database name.
 
 
 ### MySQL Resource
 
-URL syntax: `mysql://[<user>[:<pass>]@]<host>[:<port>]/<dbname>[?<dbparams>][#<fragment>]`
+URL syntax: `mysql://[<user>[:<pass>]@]<host>[:<port>][/<dbname>][?<dbparams>][#<fragment>]`
 
 The URL defines a [DSN](https://en.wikipedia.org/wiki/Data_source_name).
+
+The database name `<dbname>` is optional. If provided, the resource is
+classified as available as soon as the database was found.
 
 DB Parameters:
 
@@ -112,7 +118,7 @@ Fragment:
 - `tables[=t1,t2,...]` key-value: If key present and value absent, the
   resource's database scheme must at least contain one table. If key present and
   value present, the resource's database scheme must at least contain the
-  specified tables.
+  specified tables. Using this key requires to provide a database name.
 
 
 ### Command Resource

--- a/postgresql.go
+++ b/postgresql.go
@@ -37,12 +37,19 @@ type postgresqlResource struct {
 }
 
 func (r *postgresqlResource) Await(ctx context.Context) error {
-	// Keep original resource value unmodified
-	dsnURL := r.URL
-
-	// Parse and remove tags from fragment
 	tags := parseTags(r.URL.Fragment)
-	dsnURL.Fragment = ""
+
+	database := strings.TrimPrefix(r.URL.Path, "/")
+	if strings.Contains(database, "/") {
+		return fmt.Errorf("invalid database name: %s", database)
+	}
+	if database == "" {
+		if _, ok := tags["tables"]; ok {
+			return fmt.Errorf("database name required for awaiting tables")
+		}
+		// Special database default which usually exists.
+		database = "information_schema"
+	}
 
 	// Disable TLS/SSL by default
 	query, err := url.ParseQuery(r.URL.RawQuery)
@@ -52,8 +59,11 @@ func (r *postgresqlResource) Await(ctx context.Context) error {
 	if query.Get("sslmode") == "" {
 		query.Set("sslmode", "disable")
 	}
-	dsnURL.RawQuery = query.Encode()
 
+	dsnURL := r.URL
+	dsnURL.Fragment = ""
+	dsnURL.Path = database
+	dsnURL.RawQuery = query.Encode()
 	dsn := dsnURL.String()
 
 	db, err := sql.Open(dsnURL.Scheme, dsn)
@@ -71,7 +81,7 @@ func (r *postgresqlResource) Await(ctx context.Context) error {
 		if val != "" {
 			tables = strings.Split(val, ",")
 		}
-		if err := awaitPostgreSQLTables(db, dsnURL.Path[1:], tables); err != nil {
+		if err := awaitPostgreSQLTables(db, database, tables); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
If the database name, as path, is not provided, fallback to a database that most likely does exist: `information_schema`. This should work in most cases for MySQL/MariaDB and PostgreSQL.

Note: The `tables` fragment key requires a database name is set.

Fixes #19.