### PR TITLE
Only log transient resource unavailability in extra verbose output mode

### DIFF
--- a/awaiter.go
+++ b/awaiter.go
@@ -52,6 +52,8 @@ func (a *awaiter) run(resources []resource) error {
 
 	go func() {
 		for _, res := range resources {
+			a.logger.Infof("Awaiting resource: %s", res)
+
 			for {
 				select {
 				case <-ctx.Done():
@@ -61,7 +63,6 @@ func (a *awaiter) run(resources []resource) error {
 					// Still time left, let's continue
 				}
 
-				a.logger.Infof("Awaiting resource: %s", res)
 				if latestErr = res.Await(ctx); latestErr != nil {
 					if e, ok := latestErr.(*unavailabilityError); ok {
 						// transient error

--- a/awaiter.go
+++ b/awaiter.go
@@ -65,7 +65,7 @@ func (a *awaiter) run(resources []resource) error {
 				if latestErr = res.Await(ctx); latestErr != nil {
 					if e, ok := latestErr.(*unavailabilityError); ok {
 						// transient error
-						a.logger.Infof("Resource unavailable: %v", e)
+						a.logger.Debugf("Resource unavailable: %v", e)
 					} else {
 						// Maybe transient error
 						a.logger.Errorf("Error: failed to await resource: %v", latestErr)

--- a/log.go
+++ b/log.go
@@ -27,7 +27,8 @@ import (
 
 // An enumeration of log levels.
 const (
-	infoLevel = iota
+	debugLevel = iota
+	infoLevel
 	errorLevel
 	silentLevel
 )
@@ -44,6 +45,30 @@ func NewLogger(level int) *LevelLogger {
 	return &LevelLogger{
 		Logger: log.New(os.Stderr, "", log.LstdFlags),
 		level:  level,
+	}
+}
+
+// Debug logs a message if the current log level is below or equal to
+// debugLevel.
+func (l *LevelLogger) Debug(v ...interface{}) {
+	if l.level <= debugLevel {
+		log.Print(v...)
+	}
+}
+
+// Debugln logs a message if the current log level is below or equal to
+// debugLevel.
+func (l *LevelLogger) Debugln(v ...interface{}) {
+	if l.level <= debugLevel {
+		log.Println(v...)
+	}
+}
+
+// Debugf logs a message if the current log level is below or equal to
+// debugLevel.
+func (l *LevelLogger) Debugf(format string, v ...interface{}) {
+	if l.level <= debugLevel {
+		log.Printf(format, v...)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -72,8 +72,8 @@ func main() {
 
 	if err := awaiter.run(ress); err != nil {
 		if e, ok := err.(*unavailabilityError); ok {
-			logger.Infof("Resource unavailable: %v", e)
-			logger.Infoln("Timeout exceeded")
+			logger.Errorf("Resource unavailable: %v", e)
+			logger.Errorln("Timeout exceeded")
 		} else {
 			logger.Fatalln("Error: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -31,10 +31,11 @@ import (
 
 func main() {
 	var (
-		forceFlag   = flag.Bool("f", false, "Force running the command even after giving up")
-		timeoutFlag = flag.Duration("t", 1*time.Minute, "Timeout duration before giving up")
-		verboseFlag = flag.Bool("v", false, "Set verbose output")
-		quietFlag   = flag.Bool("q", false, "Set quiet mode")
+		forceFlag    = flag.Bool("f", false, "Force running the command even after giving up")
+		timeoutFlag  = flag.Duration("t", 1*time.Minute, "Timeout duration before giving up")
+		verbose1Flag = flag.Bool("v", false, "Set verbose output mode")
+		verbose2Flag = flag.Bool("vv", false, "Set more verbose output mode")
+		quietFlag    = flag.Bool("q", false, "Set quiet mode")
 	)
 	flag.Usage = func() {
 		fmt.Fprintln(os.Stderr, "Usage: await [options...] <res>... [ -- <cmd>]")
@@ -48,8 +49,10 @@ func main() {
 	switch {
 	case *quietFlag:
 		logLevel = silentLevel
-	case *verboseFlag:
+	case *verbose1Flag:
 		logLevel = infoLevel
+	case *verbose2Flag:
+		logLevel = debugLevel
 	default:
 		logLevel = errorLevel
 	}


### PR DESCRIPTION
This change the current output as follows:

On success with `-v` (old behaviour):

    2016/11/25 15:43:01 Awaiting resource: mysql://user:pass@db:3306/db#tables
    2016/11/25 15:43:01 Resource unavailable: dial tcp 172.20.0.4:3306: getsockopt: connection refused
    2016/11/25 15:43:02 Awaiting resource: mysql://user:pass@db:3306/db#tables
    2016/11/25 15:43:02 Resource unavailable: dial tcp 172.20.0.4:3306: getsockopt: connection refused
    2016/11/25 15:43:02 Awaiting resource: mysql://user:pass@db:3306/db#tables
    2016/11/25 15:43:02 Resource unavailable: dial tcp 172.20.0.4:3306: getsockopt: connection refused
    2016/11/25 15:43:04 Awaiting resource: mysql://user:pass@db:3306/db#tables
    :
    2016/11/25 15:43:04 All resources available

On success with `-v`:

    2016/11/25 15:43:01 Awaiting resource: mysql://user:pass@db:3306/db#tables
    2016/11/25 15:43:04 All resources available

On success with `-vv`:

    2016/11/25 15:43:01 Awaiting resource: mysql://user:pass@db:3306/db#tables
    2016/11/25 15:43:01 Resource unavailable: dial tcp 172.20.0.4:3306: getsockopt: connection refused
    2016/11/25 15:43:02 Resource unavailable: dial tcp 172.20.0.4:3306: getsockopt: connection refused
    2016/11/25 15:43:02 Resource unavailable: dial tcp 172.20.0.4:3306: getsockopt: connection refused
    :
    2016/11/25 15:43:04 All resources available

On failure without `-v` (old behaviour):

    2016/11/25 16:04:33 Resource unavailable: dial tcp: 172.20.0.4:3306: getsockopt: connection
    2016/11/25 16:04:33 Timeout exceeded

On failure without `-v`:

    2016/11/25 16:04:33 Resource unavailable: dial tcp: 172.20.0.4:3306: getsockopt: connection
    2016/11/25 16:04:33 Timeout exceeded

On failure with `-v`:

    2016/11/25 15:40:59 Awaiting resource: mysql://user:pass@db:3306/db#tables
    2016/11/25 15:41:59 Resource unavailable: dial tcp: lookup db: no such host
    2016/11/25 15:41:59 Timeout exceeded

On failure with `-vv`:

    2016/11/25 15:46:21 Awaiting resource: mysql://user:pass@db:3306/db#tables
    2016/11/25 15:46:21 Resource unavailable: dial tcp: lookup db: no such host
    2016/11/25 15:46:21 Resource unavailable: dial tcp: lookup db: no such host
    2016/11/25 15:46:21 Resource unavailable: dial tcp: lookup db: no such host
    :
    2016/11/25 15:47:21 Timeout exceeded

Closes #22.