### PR TITLE
Read resources from file or stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ or
     Await availability of resources.
 
       -f	Force running the command even after giving up
+      -i string
+        	Read resources from file, '-' to read from stdin
       -q	Set quiet mode
       -t duration
         	Set timeout duration before giving up (default 1m0s)


### PR DESCRIPTION
Additionally, check if stdin comes from a pipe. If, this overrides any infile flag value, even `-`.

So possible scenarios are:

1. From file:

       await -i res.txt -- echo OK
       OK

2. Stdin from infile:

       cat res.txt | await -i - -- echo OK
       OK

3. Stdin from pipe:

       cat res.txt | await -- echo OK
       OK

Closes #21.