### PR TITLE
Update Travis configuration to actively verify 1.8 major release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
     - 1.7
+    - 1.8
     - master
 install: make deps
 script: make test


### PR DESCRIPTION
We always had `1.7` and `master` (aka `tip`). Now since 1.8 is officially release this change will actively check for _1.8_.