### PR TITLE
Add skip tls verification option to https resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ notifications:
   email: false
 
 go:
-    - 1.7.x
-    - 1.8.x
     - 1.9.x
     - 1.10.x
     - 1.11.x

--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ Valid resources are: HTTP, Websocket, TCP, File, PostgreSQL, MySQL, Command.
 and an empty request returns the response status code is 2xx. Unavailable
 otherwise.
 
-**URL syntax**: `http[s]://[<user>[:<pass>]@]<host>[:<port>][<path>][?<query>]`
+**URL syntax**: `http[s]://[<user>[:<pass>]@]<host>[:<port>][<path>][?<query>][#<fragment>]`
 
+**Fragment**:
+
+- `tls=skip-verify`: When used, it skips TLS check for `https` resources.
 
 ### Websocket Resource
 

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2016-2018 Betalo AB
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestTLSSkipVerify(t *testing.T) {
+	shutdownServer := setupHttpsServer(t)
+	defer shutdownServer()
+
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+
+	resources, _ := parseResources([]string{
+		"https://localhost:55372",
+		"https://localhost:55372#tls=skip-verify",
+	})
+
+	if err := resources[0].Await(ctx); err == nil {
+		t.Errorf("Should have failed when verifying TLS, but succeeded.")
+	}
+
+	if err := resources[1].Await(ctx); err != nil {
+		t.Errorf("Should have skipped TLS verification, but didn't: %v", err)
+	}
+}
+
+func setupHttpsServer(t *testing.T) func() {
+	certFile, keyFile, cleanupCerts := setupTestCertificates(t)
+
+	server := &http.Server{
+		Addr: ":55372",
+	}
+
+	http.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+		_, _ = fmt.Fprint(res, "Hello: "+req.Host)
+	})
+
+	// The separation of the listening socket from the serving of the http requests
+	// is to guarantee one can immediately contact the server on this method's return
+	ln, err := net.Listen("tcp", ":55372")
+	if err != nil {
+		t.Errorf("Unable to setup listening socket for webserver: %v", err)
+	}
+
+	go func() {
+		_ = server.ServeTLS(ln, certFile, keyFile)
+	}()
+
+	return func() {
+		_ = server.Close()
+		_ = ln.Close()
+		cleanupCerts()
+	}
+}
+
+func setupTestCertificates(t *testing.T) (string, string, func()) {
+	certFile := "testCert.crt"
+	keyFile := "testCert.key"
+	cert, key, err := CertWithKeyPair()
+	if err != nil {
+		t.Errorf("failed to generate test certificates: %v", err)
+	}
+	if err := ioutil.WriteFile(certFile, cert, 0644); err != nil {
+		t.Errorf("failed to write cert fixture to %s: %v", certFile, err)
+	}
+	if err := ioutil.WriteFile(keyFile, key, 0644); err != nil {
+		t.Errorf("failed to write key fixture to %s: %v", keyFile, err)
+	}
+	return certFile, keyFile, func() {
+		_ = os.Remove(certFile)
+		_ = os.Remove(keyFile)
+	}
+}
+
+func CertWithKeyPair() ([]byte, []byte, error) {
+	bits := 2048
+	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "wronghost"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(2, 0, 0),
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	derCert, err := x509.CreateCertificate(rand.Reader, &tpl, &tpl, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	buf := &bytes.Buffer{}
+	err = pem.Encode(buf, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derCert,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pemCert := buf.Bytes()
+
+	buf = &bytes.Buffer{}
+	err = pem.Encode(buf, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	pemKey := buf.Bytes()
+
+	return pemCert, pemKey, nil
+}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 	"time"
 )
 
-const version = "0.4.0"
+const version = "1.1.0"
 
 func main() {
 	var (


### PR DESCRIPTION
Hello,

  I'e added a functionality that I've come to be in need from `await`. 
  The use case is when (in docker), the system under test has self-signed certificates (since, for tests, those are "enough", while in production proper certificates would be available).
  I used the same method as for the DB related ones, adding a flag on the fragment part of the URL for http resource.

  I added the equivalent test for the functionality (the test is much more code than the the functionality... :) )

  I also bumped the version of the tool to `1.1.0`, since it seems that version 1.0.0 was released, but never actually bumped in the code.

  Also, please give my kind regards to Kevin A. :)

